### PR TITLE
Return `object`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,4 +9,6 @@ module.exports = (obj, context) => {
 			obj[key] = val.bind(context);
 		}
 	}
+
+	return obj;
 };

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ message2();
 
 ### bindMethods(object, [context])
 
-Bind methods in `object` to itself or `context` if specified.
+Bind methods in `object` to itself or `context` if specified and returns the `object` object.
 
 #### object
 

--- a/readme.md
+++ b/readme.md
@@ -36,11 +36,11 @@ message2();
 
 ## API
 
-### bindMethods(object, [context])
+### bindMethods(input, [context])
 
-Bind methods in `object` to itself or `context` if specified and returns the `object` object.
+Bind methods in `input` to itself or `context` if specified. Returns the `input` object.
 
-#### object
+#### input
 
 Type: `Object`
 

--- a/test.js
+++ b/test.js
@@ -12,7 +12,8 @@ test(t => {
 	const message = unicorn.message;
 	t.throws(() => message(), /Cannot read/);
 
-	m(unicorn);
+	const bounded = m(unicorn);
+	t.is(bounded, unicorn);
 
 	const message2 = unicorn.message;
 	t.is(message2(), 'Rainbow is awesome!');


### PR DESCRIPTION
This would simplify some use cases, e.g. with [`pify`](https://github.com/sindresorhus/pify):

```js
const legacyUnicorn = {
    name: 'Rainbow',
    message(cb) {
        cb(null, `${this.name} is awesome!`);
    }
};

// instead of
bindMethods(legacyUnicorn);
const unicorn = pify(legacyUnicorn);

// we are able to
const unicorn = pify(bindMethods(legacyUnicorn));
```